### PR TITLE
[fix] checkArrayValueIsMulti

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -120,6 +120,9 @@ func checkArrayValueIsMulti(value reflect.Value) (ok bool, fieldNum int) {
 	if !ok {
 		return
 	}
+	if kind == reflect.Map {
+		return false, 0
+	}
 	//检查值的类型是不是 map、array、map 或 struct
 	valueKind := value.Type().Elem().Kind()
 

--- a/validates_test.go
+++ b/validates_test.go
@@ -71,9 +71,12 @@ func TestRequired(t *testing.T) {
 	testMap := []struct {
 		param    map[string]string `validate:"required"`
 		expected bool
+		mapStruct map[string]struct{}
 	}{
-		{map[string]string{"a": "aa", "b": "bb"}, true},
-		{map[string]string{}, false},
+		{map[string]string{"a": "aa", "b": "bb"}, true, map[string]struct{}{
+			"1": {},
+		}},
+		{map[string]string{}, false, map[string]struct{}{}},
 	}
 	for _, test := range testMap {
 		err := validator.Validate(test)


### PR DESCRIPTION
`checkArrayValueIsMulti` 判断有误，对于 Map 类型应该是不能再去 Index 索引，添加一个 测试样例可以复现问题
```
panic: reflect: call of reflect.Value.Index on map Value [recovered]
	panic: reflect: call of reflect.Value.Index on map Value
```